### PR TITLE
[Style]함수 안에 매개변수를 리턴하는 과정에서 스코프 제거

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -6,5 +6,5 @@
     "singleQuote": false,
     "trailingComma": "all",
     "bracketSpacing": true,
-    "arrowParens": "always"
+    "arrowParens": "avoid"
 }


### PR DESCRIPTION
# 설명
화살표 함수 안에서 하나의 매개변수를 리턴하면 스코프로 감싸줄 필요없다 생각이 들어 prettier파일을 수정하였습니다. 

## 무슨 종류의 PR인지?

- [ ] 🕹️ Feat 
- [ ] 📌 Fix
- [ ] 🔖 Documentation Update
- [X] 🎨 Style 
- [ ] 🔎 Code Refactor 
- [ ] ✅ Test 
- [ ] 🤖 Build 
- [ ] 📦 Chore
- [ ] ⏩ Revert 

# 어떻게 테스트 되었는가?

- [ ] 테스트 코드 작성
- [ ] 로컬환경에서 수동 테스트 진행

# 티켓 번호
[JAE-19](https://linear.app/jaehyeok/issue/JAE-19/[01]-%ED%94%84%EB%A6%AC%ED%8B%B0%EC%96%B4-%ED%8C%8C%EC%9D%BC-%EB%B3%80%EA%B2%BD)

