### PR TITLE
[Feat]타이틀 컴포넌트 구현

### DIFF
--- a/src/views/components/title/index.css
+++ b/src/views/components/title/index.css
@@ -1,0 +1,22 @@
+#title_container {
+    max-width: 980px;
+    margin: 0 auto;
+    padding: 0 40px;
+    box-sizing: border-box;
+}
+
+#title_inner_container {
+    width: 100%;
+}
+
+#development_container {
+    background-color: white;
+    display: inline-block;
+    padding: 20px 0px;
+    margin: 52px 0 32px 0; 
+}
+
+#development_container > h1 {
+    font-weight: 700;
+    font-size: 36px;
+}

--- a/src/views/components/title/index.js
+++ b/src/views/components/title/index.js
@@ -2,11 +2,11 @@ import "./index.css";
 
 const titleTemplate = `
 <section id="title_container">
-  <div id="title_inner_container">
-      <div id="development_container">
-        <h1>개발</h1>      
-      </div>
-  </div>
+    <div id="title_inner_container">
+        <div id="development_container">
+            <h1>개발</h1>      
+        </div>
+    </div>
 </section>
 `;
 

--- a/src/views/components/title/index.js
+++ b/src/views/components/title/index.js
@@ -11,7 +11,7 @@ const titleTemplate = `
 `;
 
 const titleComponenet = () => {
-  const title = document.getElementById("title");
+  const title = document.getElementById("title"); //Todo: JAE-37 티켓에서 app 레이아웃 구현 예정입니다.
   title.innerHTML = titleTemplate;
 };
 

--- a/src/views/components/title/index.js
+++ b/src/views/components/title/index.js
@@ -1,0 +1,18 @@
+import "./index.css";
+
+const titleTemplate = `
+<section id="title_container">
+  <div id="title_inner_container">
+      <div id="development_container">
+        <h1>개발</h1>      
+      </div>
+  </div>
+</section>
+`;
+
+const titleComponenet = () => {
+  const title = document.getElementById("title");
+  title.innerHTML = titleTemplate;
+};
+
+export default titleComponenet;


### PR DESCRIPTION
# 설명
- 추후 화면에 보여질 타이틀을 컴포넌트로 구현하였습니다.
- 3개의 컨테이너로 나누어 CSS를 적용하였습니다.
<img width="1640" alt="스크린샷 2023-12-04 오후 9 09 07" src="https://github.com/f-lab-edu/toss-tech-project/assets/98483125/8bd71085-c922-463b-a98e-f9023e82ecf5">


## 무슨 종류의 PR인지?

- [X] 🕹️ Feat 
- [ ] 📌 Fix
- [ ] 🔖 Documentation Update
- [ ] 🎨 Style 
- [ ] 🔎 Code Refactor 
- [ ] ✅ Test 
- [ ] 🤖 Build 
- [ ] 📦 Chore
- [ ] ⏩ Revert 

# 어떻게 테스트 되었는가?

- [ ] 테스트 코드 작성
- [X] 로컬환경에서 수동 테스트 진행

> 실행결과
<img width="1139" alt="스크린샷 2023-12-04 오후 9 11 13" src="https://github.com/f-lab-edu/toss-tech-project/assets/98483125/b742667e-29b6-4f06-a2bd-bd95bf789f98">


# 티켓 번호
[JAE-40](https://linear.app/jaehyeok/issue/JAE-40/[3]-%ED%83%80%EC%9D%B4%ED%8B%80-%EC%BB%B4%ED%8F%AC%EB%84%8C%ED%8A%B8)

