### PR TITLE
[Feat]콘텐트 컴포넌트 구현

### DIFF
--- a/src/views/components/content/index.css
+++ b/src/views/components/content/index.css
@@ -1,0 +1,43 @@
+#detail_container {
+    max-width: 700px;
+    box-sizing: border-box;
+    padding: 0 28px;
+    margin: 0 auto;
+}
+
+#detail_inner_container {
+    width: 100%;  
+}
+
+#detail_img_container {
+    max-width: 644px;
+    width: 100%;
+    margin-top: 36px;  
+}
+
+#detail_img_container img {
+    width: 100%;
+    height: 100%;
+    border-radius: 12px;
+}
+
+#detail_title_container {
+    margin-top: 20px;
+}
+
+#detail_title_container > h1 {
+    font-size: 48px;
+    font-weight: 700;
+}
+
+#detail_created_container {
+    margin-top: 20px;
+}
+
+#detail_created_container p {
+    color: #8b95a1;
+}
+
+#detail_content_container {
+    margin-top: 54px;
+}

--- a/src/views/components/content/index.js
+++ b/src/views/components/content/index.js
@@ -1,0 +1,35 @@
+import formatDate from "../list/format-date";
+import "./index.css";
+
+const contentTemplate = (head, body) => ` 
+<main>
+  <div id="detail_container">
+    <div id="detail_inner_container">
+      <div id="detail_img_container">
+        <img src="${
+          head.thumbnail_image
+        }" alt="상세 페이지에 들어있는 이미지" />
+      </div>
+      <section>
+        <div id="detail_title_container">
+          <h1>${head.title}</h1>
+        </div>
+        <div id="detail_created_container">
+          <p>${formatDate(head.created_date)}</p>
+        </div>
+        <div id="detail_content_container">
+          <p>${body}</p>
+        </div>
+      <section>
+    </div>
+  </div>
+</main>
+`;
+
+//Todo: JAE_28 티켓에서 컨트롤러 구현을 통해 head와 body를 받아올 예정입니다.
+const contentComponet = (head, body) => {
+  const main = document.getElementById("main"); //Todo: JAE-37 티켓에서 app 레이아웃 구현 예정입니다.
+  main.innerHTML = contentTemplate(head, body);
+};
+
+export default contentComponet;


### PR DESCRIPTION
# 설명
- 추후 화면에 보여질 콘텐트를 컴포넌트로 구현하였습니다.
- 5개의 컨테이너로 나누었습니다.
<img width="898" alt="스크린샷 2023-12-11 오전 4 19 12" src="https://github.com/f-lab-edu/toss-tech-project/assets/98483125/e3730629-8eb9-4869-a1fd-2aaf41dcfd4d">

## 무슨 종류의 PR인지?

- [X] 🕹️ Feat 
- [ ] 📌 Fix
- [ ] 🔖 Documentation Update
- [ ] 🎨 Style 
- [ ] 🔎 Code Refactor 
- [ ] ✅ Test 
- [ ] 🤖 Build 
- [ ] 📦 Chore
- [ ] ⏩ Revert 

# 어떻게 테스트 되었는가?

- [ ] 테스트 코드 작성
- [X] 로컬환경에서 수동 테스트 진행
> 실행화면
<img width="916" alt="스크린샷 2023-12-11 오전 4 06 56" src="https://github.com/f-lab-edu/toss-tech-project/assets/98483125/bff1d5ed-1e3b-4b4a-8e5e-0bb559959b19">

# 티켓 번호
[JAE-44](https://linear.app/jaehyeok/issue/JAE-44/[2]-%EC%BD%98%ED%85%90%ED%8A%B8-%EC%BB%B4%ED%8F%AC%EB%84%8C%ED%8A%B8)

